### PR TITLE
revert: undo test changes made by mistake

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -59,9 +59,11 @@ jobs:
           SECRETS_VALID=true
           MISSING_SECRETS=()
 
-          # Check ANTHROPIC_API_KEY (optional - not needed with Claude Code subscription)
+          # Check ANTHROPIC_API_KEY
           if [[ -z "${{ secrets.ANTHROPIC_API_KEY }}" ]]; then
-            echo "ℹ️  ANTHROPIC_API_KEY is not set (optional with Claude Code subscription)"
+            echo "❌ ANTHROPIC_API_KEY is not set"
+            MISSING_SECRETS+=("ANTHROPIC_API_KEY")
+            SECRETS_VALID=false
           else
             echo "✅ ANTHROPIC_API_KEY is set"
           fi


### PR DESCRIPTION
Reverting commit 8740420 (ANTHROPIC_API_KEY fix) that was created during testing by mistake.

This restores the repository to its original state before the accidental testing.